### PR TITLE
Added `generate(:hex)` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ iex(1)> UUID5.generate
 "96bcc916-6bbc-5f61-8d88-bd83ed4b0b17"
 ```
 
+* Generate UUID5 string based on DNS without dashes
+
+```elixir
+iex(1)> UUID5.generate(:hex)
+"96bcc9166bbc5f618d88bd83ed4b0b17"
+```
+
 * Set UUID5 type for field in your model
 
 ```elixir

--- a/lib/uuid5.ex
+++ b/lib/uuid5.ex
@@ -56,6 +56,12 @@ defmodule UUID5 do
     UUID.uuid5(:dns, UUID.uuid4)
   end
 
+  @doc """
+  Generates a version 5 (dns) UUID without dashes.
+  """
+  def generate(:hex) do
+    UUID.uuid5(:dns, UUID.uuid4, :hex)
+  end
+
   def autogenerate, do: generate()
 end
-


### PR DESCRIPTION
Added `generate(:hex)` function to generate an UUID5 value without dashes.